### PR TITLE
Feat: enable passing callback instead of  url to exporter config

### DIFF
--- a/lib/otel_metric_exporter/otel_api.ex
+++ b/lib/otel_metric_exporter/otel_api.ex
@@ -45,6 +45,12 @@ defmodule OtelMetricExporter.OtelApi do
     |> send_proto("/v1/logs", api)
   end
 
+  def send_metrics(%__MODULE__{config: config}, metrics) when not is_nil(config.exporter_callback) do
+    config.exporter_callback.(metrics)
+
+    :ok
+  end
+
   def send_metrics(%__MODULE__{config: config} = api, metrics) do
     metrics
     |> Protocol.build_metric_service_request(config.resource)

--- a/lib/otel_metric_exporter/otel_api.ex
+++ b/lib/otel_metric_exporter/otel_api.ex
@@ -144,7 +144,7 @@ defmodule OtelMetricExporter.OtelApi do
   defp maybe_compress(body, _), do: body
 
   defp execute_export_callback(batch, type, config) do
-    case config.export_callback.(batch, type, config) do
+    case config.export_callback.({type, batch}, config) do
       {:error, _} = error -> error
       _ -> :ok
     end

--- a/lib/otel_metric_exporter/otel_api/config.ex
+++ b/lib/otel_metric_exporter/otel_api/config.ex
@@ -6,7 +6,7 @@ defmodule OtelMetricExporter.OtelApi.Config do
     :otlp_protocol,
     :otlp_headers,
     :otlp_timeout,
-    :exporter_callback,
+    :export_callback,
     :exporter,
     :resource,
     :otlp_compression,
@@ -71,10 +71,16 @@ defmodule OtelMetricExporter.OtelApi.Config do
       default: 10,
       doc: "Number of concurrent requests to send to the OTLP endpoint."
     ],
-    exporter_callback: [
-      type: {:or, [{:fun, 1}, nil]},
+    export_callback: [
+      type: {:or, [{:fun, 3}, nil]},
       default: nil,
-      doc: "A callback function invoked instead of making an HTTP request. Must have arity 1"
+      doc: """
+      A callback function invoked instead of making an HTTP request. Should accept as arguments:
+
+      - `batch`: list of signals to be exported
+      - `type`:  kind of signal (:metrics or :logs)
+      - `config`: the options passed to this OtelMetricExporter instance
+      """
     ],
     resource: [
       type: {:map, {:or, [:atom, :string]}, :any},

--- a/lib/otel_metric_exporter/otel_api/config.ex
+++ b/lib/otel_metric_exporter/otel_api/config.ex
@@ -6,6 +6,7 @@ defmodule OtelMetricExporter.OtelApi.Config do
     :otlp_protocol,
     :otlp_headers,
     :otlp_timeout,
+    :exporter_callback,
     :exporter,
     :resource,
     :otlp_compression,
@@ -69,6 +70,11 @@ defmodule OtelMetricExporter.OtelApi.Config do
       type: :non_neg_integer,
       default: 10,
       doc: "Number of concurrent requests to send to the OTLP endpoint."
+    ],
+    exporter_callback: [
+      type: {:or, [{:fun, 1}, nil]},
+      default: nil,
+      doc: "A callback function invoked instead of making an HTTP request. Must have arity 1"
     ],
     resource: [
       type: {:map, {:or, [:atom, :string]}, :any},

--- a/lib/otel_metric_exporter/otel_api/config.ex
+++ b/lib/otel_metric_exporter/otel_api/config.ex
@@ -72,13 +72,12 @@ defmodule OtelMetricExporter.OtelApi.Config do
       doc: "Number of concurrent requests to send to the OTLP endpoint."
     ],
     export_callback: [
-      type: {:or, [{:fun, 3}, nil]},
+      type: {:or, [{:fun, 2}, nil]},
       default: nil,
       doc: """
       A callback function invoked instead of making an HTTP request. Should accept as arguments:
 
-      - `batch`: list of signals to be exported
-      - `type`:  kind of signal (:metrics or :logs)
+      - `{type, batch}`: kind (:metrics or :logs) and list of signals
       - `config`: the options passed to this OtelMetricExporter instance
       """
     ],

--- a/test/otel_metric_exporter/otel_api/config_test.exs
+++ b/test/otel_metric_exporter/otel_api/config_test.exs
@@ -39,7 +39,8 @@ defmodule OtelMetricExporter.OtelApi.ConfigTest do
                   resource: %{},
                   otlp_headers: %{},
                   otlp_protocol: :http_protobuf,
-                  otlp_timeout: 10000
+                  otlp_timeout: 10000,
+                  export_callback: nil
                 }}
     end
 
@@ -67,7 +68,8 @@ defmodule OtelMetricExporter.OtelApi.ConfigTest do
                   otlp_headers: %{},
                   otlp_protocol: :http_protobuf,
                   otlp_timeout: 10000,
-                  otlp_endpoint: "http://localhost:4317"
+                  otlp_endpoint: "http://localhost:4317",
+                  export_callback: nil
                 }}
     end
 
@@ -98,7 +100,8 @@ defmodule OtelMetricExporter.OtelApi.ConfigTest do
                   otlp_headers: %{},
                   otlp_protocol: :http_protobuf,
                   otlp_timeout: 10000,
-                  otlp_endpoint: "http://localhost:4317"
+                  otlp_endpoint: "http://localhost:4317",
+                  export_callback: nil
                 }}
     end
   end

--- a/test/otel_metric_exporter/otel_api_test.exs
+++ b/test/otel_metric_exporter/otel_api_test.exs
@@ -98,7 +98,7 @@ defmodule OtelMetricExporter.OtelApiTest do
       pid = self()
 
       callback =
-        fn [metric], :metrics, %Config{} ->
+        fn {:metrics, [metric]}, %Config{} ->
           send(pid, metric.description)
         end
 
@@ -116,7 +116,7 @@ defmodule OtelMetricExporter.OtelApiTest do
       pid = self()
 
       callback =
-        fn [log], :logs, %Config{} ->
+        fn {:logs, [log]}, %Config{} ->
           {:string_value, message} = log.body.value
 
           send(pid, message)

--- a/test/otel_metric_exporter/otel_api_test.exs
+++ b/test/otel_metric_exporter/otel_api_test.exs
@@ -2,6 +2,8 @@ defmodule OtelMetricExporter.OtelApiTest do
   use ExUnit.Case, async: false
   alias OtelMetricExporter.OtelApi
   alias OtelMetricExporter.OtelApi.Config
+  alias OtelMetricExporter.Opentelemetry.Proto.Logs.V1.LogRecord
+  alias OtelMetricExporter.Opentelemetry.Proto.Metrics.V1.Metric
 
   setup do
     on_exit(fn ->
@@ -88,6 +90,44 @@ defmodule OtelMetricExporter.OtelApiTest do
                  },
                  :metrics
                )
+    end
+  end
+
+  describe "send_metrics/2" do
+    test "if :config has export_callback, executes it instead of sending HTTP request" do
+      pid = self()
+
+      callback =
+        fn [metric], :metrics, %Config{} ->
+          send(pid, metric.description)
+        end
+
+      metrics = [%Metric{description: "callback executed"}]
+
+      %OtelApi{config: %Config{export_callback: callback}}
+      |> OtelApi.send_metrics(metrics)
+
+      assert_received "callback executed"
+    end
+  end
+
+  describe "send_log_events/2" do
+    test "if :config has export_callback, executes it instead of sending HTTP request" do
+      pid = self()
+
+      callback =
+        fn [log], :logs, %Config{} ->
+          {:string_value, message} = log.body.value
+
+          send(pid, message)
+        end
+
+      logs = [%LogRecord{body: %{value: {:string_value, "callback executed"}}}]
+
+      %OtelApi{config: %Config{export_callback: callback}}
+      |> OtelApi.send_log_events(logs)
+
+      assert_received "callback executed"
     end
   end
 end


### PR DESCRIPTION
This change allows the exporter to pass signals to a callback function instead of sending them to an URL.

With this, the signal can be:

- Pre-processed or transformed before delivery
- Redirected to non-HTTP targets
- Or even handled locally without being sent anywhere

The immediate goal is to enable individual users to define custom sources, but this flexibility may open the door to broader use cases in the future.