### PR TITLE
feat: limit metrics store memory usage

### DIFF
--- a/lib/otel_metric_exporter/metric_store.ex
+++ b/lib/otel_metric_exporter/metric_store.ex
@@ -206,7 +206,7 @@ defmodule OtelMetricExporter.MetricStore do
 
   defp above_memory_limit?(state) do
     memory_size = :ets.info(state.metrics_table, :memory) * :erlang.system_info(:wordsize)
-    memory_size >= state.api.config.max_table_memory
+    memory_size > state.api.config.max_table_memory
   end
 
   defp has_older_gens?(state) do
@@ -292,8 +292,8 @@ defmodule OtelMetricExporter.MetricStore do
 
   defp earliest_gen(generations_table) do
     case :ets.first(generations_table) do
-        :"$end_of_table" -> 0
-        x -> x
+      :"$end_of_table" -> 0
+      x -> x
     end
   end
 

--- a/lib/otel_metric_exporter/metric_store.ex
+++ b/lib/otel_metric_exporter/metric_store.ex
@@ -93,8 +93,6 @@ defmodule OtelMetricExporter.MetricStore do
     ets_key = {generation, string_name, metric_type(metric), tags, nil}
 
     :ets.update_counter(metrics_table, ets_key, 1, {ets_key, 0, nil})
-
-    trim_metrics_table(metrics_table)
   end
 
   def write_metric(metrics_table, %Metrics.Sum{} = metric, string_name, value, tags) do
@@ -102,16 +100,12 @@ defmodule OtelMetricExporter.MetricStore do
     ets_key = {generation, string_name, metric_type(metric), tags, nil}
 
     :ets.update_counter(metrics_table, ets_key, value, {ets_key, 0, nil})
-
-    trim_metrics_table(metrics_table)
   end
 
   def write_metric(metrics_table, %Metrics.LastValue{} = metric, string_name, value, tags) do
     generation = :persistent_term.get(generation_key(metrics_table))
     ets_key = {generation, string_name, metric_type(metric), tags, nil}
     :ets.update_element(metrics_table, ets_key, {2, value}, {ets_key, value, nil})
-
-    trim_metrics_table(metrics_table)
   end
 
   def write_metric(metrics_table, %Metrics.Distribution{} = metric, string_name, value, tags) do
@@ -127,8 +121,6 @@ defmodule OtelMetricExporter.MetricStore do
       [update_counter_op, update_sum_op],
       {ets_key, 0, 0}
     )
-
-    trim_metrics_table(metrics_table)
   end
 
   defp find_bucket(%Metrics.Distribution{reporter_options: opts}, value) do
@@ -140,9 +132,6 @@ defmodule OtelMetricExporter.MetricStore do
       idx -> idx
     end
   end
-
-  defp trim_metrics_table(table),
-    do: GenServer.cast(table, :trim)
 
   @impl true
   def init(config) do
@@ -193,29 +182,6 @@ defmodule OtelMetricExporter.MetricStore do
     {:noreply, state}
   end
 
-  @impl true
-  def handle_cast(:trim, state) do
-    if above_memory_limit?(state) && has_older_gens?(state) do
-      gen = earliest_gen(state.generations_table)
-
-      clear_generations(state, gen..gen)
-    end
-
-    {:noreply, state}
-  end
-
-  defp above_memory_limit?(state) do
-    memory_size = :ets.info(state.metrics_table, :memory) * :erlang.system_info(:wordsize)
-    memory_size > state.api.config.max_table_memory
-  end
-
-  defp has_older_gens?(state) do
-    earliest = earliest_gen(state.generations_table)
-    current = :persistent_term.get(generation_key(state.metrics_table))
-
-    earliest != current
-  end
-
   defp rotate_generation(%State{} = state) do
     current_gen = :persistent_term.get(generation_key(state.metrics_table))
     :persistent_term.put(generation_key(state.metrics_table), current_gen + 1)
@@ -228,7 +194,29 @@ defmodule OtelMetricExporter.MetricStore do
 
     :ets.insert(state.generations_table, {current_gen + 1, System.system_time(:nanosecond), nil})
 
+    trim_metrics_table(state)
+
     current_gen
+  end
+
+  defp trim_metrics_table(state) do
+    if above_memory_limit?(state) do
+      earliest_gen = earliest_gen(state.generations_table)
+      current_gen = :persistent_term.get(generation_key(state.metrics_table))
+      previous_gen = current_gen - 1
+
+      earliest_gen..previous_gen
+      |> Enum.take_while(fn gen ->
+        clear_generations(state, gen..gen)
+
+        above_memory_limit?(state)
+      end)
+    end
+  end
+
+  defp above_memory_limit?(state) do
+    memory_size = :ets.info(state.metrics_table, :memory) * :erlang.system_info(:wordsize)
+    memory_size > state.api.config.max_table_memory
   end
 
   defp export_metrics(%State{} = state) do

--- a/lib/otel_metric_exporter/otel_api/config.ex
+++ b/lib/otel_metric_exporter/otel_api/config.ex
@@ -14,7 +14,8 @@ defmodule OtelMetricExporter.OtelApi.Config do
     :hibernate_after,
     :spawn_opt,
     :max_batch_size,
-    :max_concurrency
+    :max_concurrency,
+    :max_table_memory
   ]
 
   @type protocol :: :http_protobuf
@@ -94,6 +95,11 @@ defmodule OtelMetricExporter.OtelApi.Config do
       type: :pos_integer,
       default: 3,
       doc: "Maximum number of concurrent batch exports."
+    ],
+    max_table_memory: [
+      type: :pos_integer,
+      default: 2_000_000_000,
+      doc: "Soft limit for table memory usage. Deletes old generations when surpassed."
     ],
     resource: [
       type: {:map, {:or, [:atom, :string]}, :any},

--- a/lib/otel_metric_exporter/otel_api/config.ex
+++ b/lib/otel_metric_exporter/otel_api/config.ex
@@ -99,7 +99,7 @@ defmodule OtelMetricExporter.OtelApi.Config do
     max_table_memory: [
       type: :pos_integer,
       default: 2_000_000_000,
-      doc: "Soft limit for table memory usage. Deletes old generations when surpassed."
+      doc: "Soft limit for metrics ETS table memory usage. Deletes old generations when surpassed."
     ],
     resource: [
       type: {:map, {:or, [:atom, :string]}, :any},

--- a/test/otel_metric_exporter/metric_store_test.exs
+++ b/test/otel_metric_exporter/metric_store_test.exs
@@ -119,43 +119,72 @@ defmodule OtelMetricExporter.MetricStoreTest do
       {:ok, store_config: updated_config, metric: metric}
     end
 
-    test "deletes oldest generation when threshold is surpassed", %{store_config: base_config, metric: metric} do
-      config = Map.put(base_config, :max_table_memory, 3300)
+  defp induce_rotate_generation do
+      capture_log(fn ->
+        send(@name, :export)
+        :timer.sleep(100)
+      end)
+    end
+
+    test "gen rotation deletes oldest gen when threshold is surpassed", %{store_config: base_config, metric: metric} do
+      config = Map.put(base_config, :max_table_memory, 3200)
       start_supervised!({MetricStore, config})
 
-      MetricStore.write_metric(@name, metric, 1, %{"test" => 1})
+      MetricStore.write_metric(@name, metric, 1, %{})
 
-      # Creates 2 more generations to ensure only oldest gets deleted
+      # first gen don't get deleted if the threshold were not violated yet
 
-      capture_log(fn ->
-        send(@name, :export)
-        :timer.sleep(100)
-      end)
+      induce_rotate_generation()
 
-      MetricStore.write_metric(@name, metric, 2, %{"test" => 2})
+      refute MetricStore.get_metrics(@name, 0) == %{}
 
-      capture_log(fn ->
-        send(@name, :export)
-        :timer.sleep(100)
-      end)
+      # gets deleted at rotation when threshold was violated
 
-      # generation 0 gets deleted the first time threshold is surpassed
+      MetricStore.write_metric(@name, metric, 1, %{})
 
-      MetricStore.write_metric(@name, metric, 3, %{"test" => 3})
-      MetricStore.write_metric(@name, metric, 4, %{"test" => 4})
+      induce_rotate_generation()
 
       assert MetricStore.get_metrics(@name, 0) == %{}
       refute MetricStore.get_metrics(@name, 1) == %{}
-
-      # generation 1 gets deleted if its the oldest when threshold is surpassed
-
-      MetricStore.write_metric(@name, metric, 5, %{"test" => 5})
-      :timer.sleep(100)
-
-      assert MetricStore.get_metrics(@name, 1) == %{}
     end
 
-    test "don't delete current generation when there is no older ones", %{store_config: base_config, metric: metric} do
+    test "deletes older generations until threshold is respected", %{store_config: base_config, metric: metric} do
+      config = Map.put(base_config, :max_table_memory, 3800)
+      start_supervised!({MetricStore, config})
+
+      # create multiple lightweight generations
+
+      MetricStore.write_metric(@name, metric, 1, %{"test" => 1})
+      induce_rotate_generation()
+
+      MetricStore.write_metric(@name, metric, 1,  %{"test" => 1})
+      induce_rotate_generation()
+
+      MetricStore.write_metric(@name, metric, 1,  %{"test" => 1})
+      induce_rotate_generation()
+
+      MetricStore.write_metric(@name, metric, 1,  %{"test" => 1})
+      induce_rotate_generation()
+
+      # make one generation with lots of metrics to force deleting multiple lightier ones
+
+      MetricStore.write_metric(@name, metric, 1,  %{"test" => 1})
+      MetricStore.write_metric(@name, metric, 1,  %{"test" => 2})
+      MetricStore.write_metric(@name, metric, 1,  %{"test" => 3})
+
+      # drop until meeting threshold again
+
+      induce_rotate_generation()
+
+      assert MetricStore.get_metrics(@name, 0) == %{}
+      assert MetricStore.get_metrics(@name, 1) == %{}
+      assert MetricStore.get_metrics(@name, 2) == %{}
+
+      refute MetricStore.get_metrics(@name, 3) == %{}
+      refute MetricStore.get_metrics(@name, 4) == %{}
+    end
+
+    test "threshold violation don't delete current generation when there is no older ones", %{store_config: base_config, metric: metric} do
       config = Map.put(base_config, :max_table_memory, 1)
       start_supervised!({MetricStore, config})
 


### PR DESCRIPTION
Creates a soft limit for memory usage for metric tables, deleting older generations, if any, when the threshold is reached
