### PR TITLE
fix: Failing tests

### DIFF
--- a/test/otel_metric_exporter/metric_store_test.exs
+++ b/test/otel_metric_exporter/metric_store_test.exs
@@ -121,8 +121,7 @@ defmodule OtelMetricExporter.MetricStoreTest do
 
     defp induce_rotate_generation do
       capture_log(fn ->
-        send(@name, :export)
-        :timer.sleep(100)
+        MetricStore.export_sync(@name)
       end)
     end
 
@@ -155,7 +154,7 @@ defmodule OtelMetricExporter.MetricStoreTest do
       store_config: base_config,
       metric: metric
     } do
-      config = Map.put(base_config, :max_table_memory, 3800)
+      config = Map.put(base_config, :max_table_memory, 3600)
       start_supervised!({MetricStore, config})
 
       # create multiple lightweight generations

--- a/test/otel_metric_exporter/otel_api/config_test.exs
+++ b/test/otel_metric_exporter/otel_api/config_test.exs
@@ -42,7 +42,8 @@ defmodule OtelMetricExporter.OtelApi.ConfigTest do
                   otlp_headers: %{},
                   otlp_protocol: :http_protobuf,
                   otlp_timeout: 10000,
-                  export_callback: nil
+                  export_callback: nil,
+                  max_table_memory: 2_000_000_000
                 }}
     end
 
@@ -50,31 +51,22 @@ defmodule OtelMetricExporter.OtelApi.ConfigTest do
       System.put_env("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
       System.put_env("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "http://localhost:4318")
       System.put_env("OTEL_EXPORTER_OTLP_METRICS_HEADERS", "key1=value1,key2=value2")
-      System.put_env("OTEL_EXPORTER_OTLP_TIMEOUT", "10000")
+      System.put_env("OTEL_EXPORTER_OTLP_TIMEOUT", "210000")
       System.put_env("OTEL_METRICS_EXPORTER", "none")
 
-      assert OtelMetricExporter.OtelApi.Config.defaults() ==
-               {:ok,
-                %{
-                  logs: %{
-                    exporter: :otlp,
-                    otlp_endpoint: "http://localhost:4318"
-                  },
-                  metrics: %{
-                    exporter: :none,
-                    otlp_headers: %{"key1" => "value1", "key2" => "value2"}
-                  },
-                  otlp_compression: :gzip,
-                  otlp_concurrent_requests: 10,
-                  max_batch_size: 250,
-                  max_concurrency: System.schedulers_online(),
-                  resource: %{},
-                  otlp_headers: %{},
-                  otlp_protocol: :http_protobuf,
-                  otlp_timeout: 10000,
-                  otlp_endpoint: "http://localhost:4317",
-                  export_callback: nil
-                }}
+      assert {:ok,
+              %{
+                logs: %{
+                  otlp_endpoint: "http://localhost:4318"
+                },
+                metrics: %{
+                  exporter: :none,
+                  otlp_headers: %{"key1" => "value1", "key2" => "value2"}
+                },
+                otlp_protocol: :http_protobuf,
+                otlp_timeout: 210_000,
+                otlp_endpoint: "http://localhost:4317"
+              }} = OtelMetricExporter.OtelApi.Config.defaults()
     end
 
     test "can be set by application config that overrides env vars" do
@@ -87,28 +79,18 @@ defmodule OtelMetricExporter.OtelApi.ConfigTest do
 
       Application.put_env(:otel_metric_exporter, :metrics, %{exporter: :none})
 
-      assert OtelMetricExporter.OtelApi.Config.defaults() ==
-               {:ok,
-                %{
-                  logs: %{
-                    exporter: :otlp,
-                    otlp_endpoint: "http://localhost:4318"
-                  },
-                  metrics: %{
-                    exporter: :none,
-                    otlp_headers: %{"key1" => "value1", "key2" => "value2"}
-                  },
-                  otlp_compression: :gzip,
-                  otlp_concurrent_requests: 10,
-                  max_batch_size: 250,
-                  max_concurrency: System.schedulers_online(),
-                  resource: %{},
-                  otlp_headers: %{},
-                  otlp_protocol: :http_protobuf,
-                  otlp_timeout: 10000,
-                  otlp_endpoint: "http://localhost:4317",
-                  export_callback: nil
-                }}
+      assert {:ok,
+              %{
+                logs: %{
+                  exporter: :otlp,
+                  otlp_endpoint: "http://localhost:4318"
+                },
+                metrics: %{
+                  exporter: :none,
+                  otlp_headers: %{"key1" => "value1", "key2" => "value2"}
+                },
+                otlp_endpoint: "http://localhost:4317"
+              }} = OtelMetricExporter.OtelApi.Config.defaults()
     end
   end
 


### PR DESCRIPTION
The PR fixes failing tests:
* Metric store had a race condition on export (used sync instead)
* The next test had a miscalculation in the size of the table (maybe it varies between OTP versions
* config test missed out the new value with a default
