### PR TITLE
handle malformed metric payloads

### DIFF
--- a/lib/otel_metric_exporter.ex
+++ b/lib/otel_metric_exporter.ex
@@ -137,21 +137,29 @@ defmodule OtelMetricExporter do
 
   @doc false
   def handle_metric(_event_name, measurements, metadata, %{metrics: metrics, name: name} = config) do
-    for metric <- metrics do
-      if is_nil(metric.keep) || metric.keep.(metadata) do
-        value = extract_measurement(metric, measurements, metadata)
+    Enum.each(metrics, &handle_single_metric(&1, measurements, metadata, name, config))
+  end
 
-        tags =
-          if extract_fn = config[:extract_tags] do
-            extract_fn.(metric, metadata)
-          else
-            extract_tags(metric, metadata)
-          end
+  defp handle_single_metric(metric, measurements, metadata, name, config) do
+    if is_nil(metric.keep) || metric.keep.(metadata) do
+      value = extract_measurement(metric, measurements, metadata)
 
-        metric_name = "#{Enum.join(metric.name, ".")}"
-        MetricStore.write_metric(name, metric, metric_name, value, tags)
-      end
+      tags =
+        if extract_fn = config[:extract_tags] do
+          extract_fn.(metric, metadata)
+        else
+          extract_tags(metric, metadata)
+        end
+
+      metric_name = "#{Enum.join(metric.name, ".")}"
+      MetricStore.write_metric(name, metric, metric_name, value, tags)
     end
+  rescue
+    exception ->
+      log_metric_error(metric, {:error, exception, __STACKTRACE__})
+  catch
+    kind, reason ->
+      log_metric_error(metric, {kind, reason, __STACKTRACE__})
   end
 
   defp extract_measurement(metric, measurements, metadata) do
@@ -166,5 +174,11 @@ defmodule OtelMetricExporter do
     metadata
     |> metric.tag_values.()
     |> Map.take(metric.tags)
+  end
+
+  defp log_metric_error(metric, {kind, reason, stacktrace}) do
+    Logger.warning(
+      "Failed to record telemetry metric #{inspect(metric.name)}: #{Exception.format(kind, reason, stacktrace)}"
+    )
   end
 end

--- a/lib/otel_metric_exporter/metric_store.ex
+++ b/lib/otel_metric_exporter/metric_store.ex
@@ -224,16 +224,34 @@ defmodule OtelMetricExporter.MetricStore do
     earliest_gen = earliest_gen(state.generations_table)
     metrics = collect_metrics(state, earliest_gen, current_gen)
 
-    case OtelApi.send_metrics(state.api, metrics) do
+    case send_metrics(state.api, metrics) do
       :ok ->
         if metrics != [], do: clear_generations(state, earliest_gen..current_gen//1)
         :ok
 
       {:error, reason} = err ->
-        Logger.error("Failed to export metrics: #{inspect(reason)}")
+        Logger.error("Failed to export metrics: #{format_export_error(reason)}")
         err
     end
   end
+
+  defp send_metrics(api, metrics) do
+    OtelApi.send_metrics(api, metrics)
+  rescue
+    exception ->
+      {:error, {:exception, exception, __STACKTRACE__}}
+  catch
+    kind, reason ->
+      {:error, {kind, reason, __STACKTRACE__}}
+  end
+
+  defp format_export_error({kind, reason, stacktrace}) when kind in [:throw, :exit, :error],
+    do: Exception.format(kind, reason, stacktrace)
+
+  defp format_export_error({:exception, exception, stacktrace}),
+    do: Exception.format(:error, exception, stacktrace)
+
+  defp format_export_error(reason), do: inspect(reason)
 
   defp collect_metrics(%State{} = state, earliest_gen, current_gen) do
     earliest_gen..current_gen//1

--- a/lib/otel_metric_exporter/otlp_utils.ex
+++ b/lib/otel_metric_exporter/otlp_utils.ex
@@ -8,27 +8,33 @@ defmodule OtelMetricExporter.OtlpUtils do
     ArrayValue
   }
 
-  def build_kv(tags, key_prefix \\ "") do
+  def build_kv(tags, key_prefix \\ "")
+
+  def build_kv(tags, key_prefix) when is_map(tags) or is_list(tags) do
     Enum.flat_map(tags, fn {key, value} ->
-      if is_map(value) do
-        build_kv(value, key_prefix <> to_string(key) <> ".")
-      else
-        [
-          %KeyValue{
-            key: key_prefix <> to_string(key),
-            value: %AnyValue{value: to_kv_value(value)}
-          }
-        ]
+      key = key_prefix <> key_to_string(key)
+
+      cond do
+        is_struct(value) ->
+          build_key_value(key, value)
+
+        is_map(value) ->
+          build_kv(value, key <> ".")
+
+        true ->
+          build_key_value(key, value)
       end
     end)
   end
+
+  def build_kv(_tags, _key_prefix), do: []
 
   def to_kv_value(value) when is_binary(value), do: {:string_value, value}
   def to_kv_value(value) when is_atom(value), do: {:string_value, to_string(value)}
   def to_kv_value(value) when is_integer(value), do: {:int_value, value}
   def to_kv_value(value) when is_float(value), do: {:double_value, value}
   def to_kv_value(value) when is_boolean(value), do: {:bool_value, value}
-  def to_kv_value(value) when is_struct(value), do: {:string_value, to_string(value)}
+  def to_kv_value(value) when is_struct(value), do: {:string_value, safe_to_string(value)}
 
   def to_kv_value([{k, _} | _] = value) when is_atom(k),
     do: {:kvlist_value, %KeyValueList{values: build_kv(value)}}
@@ -39,4 +45,21 @@ defmodule OtelMetricExporter.OtlpUtils do
   def to_kv_value(value) when is_tuple(value), do: to_kv_value(Tuple.to_list(value))
   def to_kv_value(value) when is_pid(value), do: to_kv_value(inspect(value))
   def to_kv_value(any), do: to_kv_value(inspect(any))
+
+  defp build_key_value(key, value) do
+    [
+      %KeyValue{
+        key: key,
+        value: %AnyValue{value: to_kv_value(value)}
+      }
+    ]
+  end
+
+  defp key_to_string(key), do: safe_to_string(key)
+
+  defp safe_to_string(value) do
+    to_string(value)
+  rescue
+    Protocol.UndefinedError -> inspect(value)
+  end
 end

--- a/test/otel_metric_exporter/metric_store_test.exs
+++ b/test/otel_metric_exporter/metric_store_test.exs
@@ -243,6 +243,37 @@ defmodule OtelMetricExporter.MetricStoreTest do
       assert MetricStore.get_metrics(@name, 0) == %{}
     end
 
+    test "exports metrics with arbitrary Elixir terms in tags", %{
+      bypass: bypass,
+      store_config: config
+    } do
+      metric = Metrics.sum("test.sum")
+      start_supervised!({MetricStore, %{config | metrics: [metric]}})
+
+      tags = %{
+        {:tuple, :key} => {:tuple, self()},
+        nested: %{self() => MapSet.new([:a])}
+      }
+
+      Bypass.expect_once(bypass, "POST", "/v1/metrics", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+
+        request = ExportMetricsServiceRequest.decode(body)
+        assert [%{scope_metrics: [%{metrics: [metric]}]}] = request.resource_metrics
+        assert {:sum, %{data_points: [%{attributes: attributes}]}} = metric.data
+
+        attribute_keys = Enum.map(attributes, & &1.key)
+        assert inspect({:tuple, :key}) in attribute_keys
+        assert Enum.any?(attribute_keys, &String.starts_with?(&1, "nested.#PID<"))
+
+        Plug.Conn.resp(conn, 200, "")
+      end)
+
+      MetricStore.write_metric(@name, metric, 1, tags)
+
+      assert :ok = MetricStore.export_sync(@name)
+    end
+
     test "handles server errors gracefully", %{bypass: bypass, store_config: config} do
       metric = Metrics.sum("test.sum")
       tags = %{test: "value"}
@@ -260,6 +291,24 @@ defmodule OtelMetricExporter.MetricStoreTest do
       assert capture_log(fn -> MetricStore.export_sync(@name) end) =~ "Failed to export metrics"
 
       # Verify metrics were not cleared due to error
+      assert MetricStore.get_metrics(@name, 0) == metrics
+    end
+
+    test "handles protobuf encoding errors gracefully", %{store_config: config} do
+      metric = Metrics.last_value("test.last_value")
+      tags = %{test: "value"}
+      start_supervised!({MetricStore, %{config | metrics: [metric]}})
+
+      MetricStore.write_metric(@name, metric, :not_a_number, tags)
+      metrics = MetricStore.get_metrics(@name)
+
+      log =
+        capture_log(fn ->
+          assert {:error, {:exception, _exception, _stacktrace}} = MetricStore.export_sync(@name)
+        end)
+
+      assert log =~ "Failed to export metrics"
+      assert Process.alive?(Process.whereis(@name))
       assert MetricStore.get_metrics(@name, 0) == metrics
     end
 

--- a/test/otel_metric_exporter_test.exs
+++ b/test/otel_metric_exporter_test.exs
@@ -164,6 +164,40 @@ defmodule OtelMetricExporterTest do
              ]) == 1
     end
 
+    test "does not detach handler when recording a metric raises" do
+      event_name = [:test, :bad_metric]
+
+      metrics = [
+        Telemetry.Metrics.sum(
+          "test.bad_metric.value",
+          event_name: event_name,
+          measurement: fn
+            _measurements, %{bad?: true} -> raise "bad telemetry payload"
+            measurements, _metadata -> measurements.value
+          end
+        )
+      ]
+
+      start_supervised!({OtelMetricExporter, @base_config ++ [metrics: metrics]})
+
+      handler_id = {OtelMetricExporter.TelemetryHandlers, @name, event_name}
+
+      log =
+        capture_log(fn ->
+          :telemetry.execute(event_name, %{value: 1}, %{bad?: true})
+          Process.sleep(50)
+        end)
+
+      assert log =~ "Failed to record telemetry metric"
+      assert Enum.any?(:telemetry.list_handlers(event_name), &(&1.id == handler_id))
+
+      :telemetry.execute(event_name, %{value: 2}, %{})
+      Process.sleep(50)
+
+      metrics = OtelMetricExporter.MetricStore.get_metrics(@name)
+      assert get_in(metrics, [{:sum, "test.bad_metric.value"}, %{}]) == 2
+    end
+
     test "handles detaching of handlers on shutdown" do
       test_event = :"event_#{inspect(self())}"
 


### PR DESCRIPTION
This has been bugging me since my mistake that was fixed in  https://github.com/Logflare/logflare/pull/3169 ... I don't think exporter should get detached on invalid payload. And right now invalid payloads are still possible. I've seen the export fail locally and get detached a few times on unexpected Ecto query timing measurements.

---

This makes metric recording and export resilient to malformed telemetry payloads. Metric callback failures are logged and skipped without detaching the telemetry handler, OTLP attribute conversion now tolerates arbitrary Elixir terms, and export encoding failures are returned as errors while retaining metrics. This prevents bad tags, tuples, pids, structs, or invalid encoded values from taking down collection/export paths. Validated with targeted regression tests and formatting checks for the touched files.