### PR TITLE
Fix/bad arg causing handler to detach

### DIFF
--- a/lib/otel_metric_exporter/metric_store.ex
+++ b/lib/otel_metric_exporter/metric_store.ex
@@ -88,6 +88,7 @@ defmodule OtelMetricExporter.MetricStore do
   def write_metric(metrics_table, metric, value, tags),
     do: write_metric(metrics_table, metric, Enum.join(metric.name, "."), value, tags)
 
+
   def write_metric(metrics_table, %Metrics.Counter{} = metric, string_name, _, tags) do
     generation = :persistent_term.get(generation_key(metrics_table))
     ets_key = {generation, string_name, metric_type(metric), tags, nil}
@@ -95,6 +96,7 @@ defmodule OtelMetricExporter.MetricStore do
     :ets.update_counter(metrics_table, ets_key, 1, {ets_key, 0, nil})
   end
 
+  def write_metric(_metrics_table, %Metrics.Sum{} = _metric, _string_name, value, _tags) when not is_number(value), do: :ok
   def write_metric(metrics_table, %Metrics.Sum{} = metric, string_name, value, tags) do
     generation = :persistent_term.get(generation_key(metrics_table))
     ets_key = {generation, string_name, metric_type(metric), tags, nil}
@@ -108,6 +110,7 @@ defmodule OtelMetricExporter.MetricStore do
     :ets.update_element(metrics_table, ets_key, {2, value}, {ets_key, value, nil})
   end
 
+  def write_metric(_metrics_table, %Metrics.Distribution{} = _metric, _string_name, value, _tags) when not is_number(value), do: :ok
   def write_metric(metrics_table, %Metrics.Distribution{} = metric, string_name, value, tags) do
     bucket = find_bucket(metric, value)
     generation = :persistent_term.get(generation_key(metrics_table))

--- a/lib/otel_metric_exporter/metric_store.ex
+++ b/lib/otel_metric_exporter/metric_store.ex
@@ -88,7 +88,6 @@ defmodule OtelMetricExporter.MetricStore do
   def write_metric(metrics_table, metric, value, tags),
     do: write_metric(metrics_table, metric, Enum.join(metric.name, "."), value, tags)
 
-
   def write_metric(metrics_table, %Metrics.Counter{} = metric, string_name, _, tags) do
     generation = :persistent_term.get(generation_key(metrics_table))
     ets_key = {generation, string_name, metric_type(metric), tags, nil}

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule OtelMetricExporter.MixProject do
       app: :otel_metric_exporter,
       name: "OTel Metric Exporter",
       description: "An unofficial OTel-compatible metric exporter",
-      version: "0.3.11",
+      version: "0.3.12",
       elixir: "~> 1.17",
       start_permanent: Mix.env() == :prod,
       source_url: "https://github.com/electric-sql/elixir-otel-metric-exporter",

--- a/test/otel_metric_exporter/metric_store_test.exs
+++ b/test/otel_metric_exporter/metric_store_test.exs
@@ -57,6 +57,19 @@ defmodule OtelMetricExporter.MetricStoreTest do
       assert %{{:sum, "test.value"} => %{^tags => 3}} = metrics
     end
 
+    test "ignores sum metrics when value is nan" do
+      metric = Metrics.sum("test.value")
+      tags = %{test: "value"}
+
+      MetricStore.write_metric(@name, metric, 1, tags)
+      MetricStore.write_metric(@name, metric, :not_supported, tags)
+      MetricStore.write_metric(@name, metric, 2, tags)
+
+      metrics = MetricStore.get_metrics(@name)
+
+      assert %{{:sum, "test.value"} => %{^tags => 3}} = metrics
+    end
+
     test "records last value metrics" do
       metric = Metrics.last_value("test.value")
       tags = %{test: "value"}
@@ -74,6 +87,25 @@ defmodule OtelMetricExporter.MetricStoreTest do
       tags = %{test: "value"}
 
       MetricStore.write_metric(@name, metric, 2, tags)
+      MetricStore.write_metric(@name, metric, 3, tags)
+      MetricStore.write_metric(@name, metric, 5, tags)
+      MetricStore.write_metric(@name, metric, 5, tags)
+
+      metrics = MetricStore.get_metrics(@name)
+
+      assert %{
+               {:distribution, "test.value"} => %{
+                 ^tags => %{0 => {1, 2}, 1 => {1, 3}, 2 => {2, 10}}
+               }
+             } = metrics
+    end
+
+    test "ignores distribution metric when value is nan" do
+      metric = Metrics.distribution("test.value", reporter_options: [buckets: [2, 4]])
+      tags = %{test: "value"}
+
+      MetricStore.write_metric(@name, metric, 2, tags)
+      MetricStore.write_metric(@name, metric, :not_supported, tags)
       MetricStore.write_metric(@name, metric, 3, tags)
       MetricStore.write_metric(@name, metric, 5, tags)
       MetricStore.write_metric(@name, metric, 5, tags)

--- a/test/otel_metric_exporter_test.exs
+++ b/test/otel_metric_exporter_test.exs
@@ -164,6 +164,26 @@ defmodule OtelMetricExporterTest do
              ]) == 1
     end
 
+    test "does not detach sum handler on bad arg" do
+      test_event = :"event_#{inspect(self())}"
+
+      metrics = [
+        Telemetry.Metrics.sum("test.event.value", event_name: [:test, test_event])
+      ]
+
+      start_supervised!({OtelMetricExporter, @base_config ++ [metrics: metrics]})
+
+      handlers = :telemetry.list_handlers([:test, test_event])
+      assert 1 == Enum.count(handlers)
+
+      :telemetry.execute([:test, test_event], %{value: :not_supported}, %{})
+
+      handlers = :telemetry.list_handlers([:test, test_event])
+      assert 1 == Enum.count(handlers)
+
+      stop_supervised!(OtelMetricExporter)
+    end
+
     test "handles detaching of handlers on shutdown" do
       test_event = :"event_#{inspect(self())}"
 


### PR DESCRIPTION
Telemetry handler crashed and detached when a bad value was given to sum.

Fix: ignores bad values.

closes O11Y-1834
